### PR TITLE
Fixed assignment where it should have been a comparison that clobbers the symbolTable in use

### DIFF
--- a/LibAPRS/LibAPRS.cpp
+++ b/LibAPRS/LibAPRS.cpp
@@ -184,7 +184,7 @@ void APRS_printSettings() {
     Serial.print(F("Message dst:  ")); if (message_recip[0] == 0) { Serial.println(F("N/A")); } else { Serial.print(message_recip); Serial.print(F("-")); Serial.println(message_recip_ssid); }
     Serial.print(F("TX Preamble:  ")); Serial.println(custom_preamble);
     Serial.print(F("TX Tail:      ")); Serial.println(custom_tail);
-    Serial.print(F("Symbol table: ")); if (symbolTable = '/') { Serial.println(F("Normal")); } else { Serial.println(F("Alternate")); }
+    Serial.print(F("Symbol table: ")); if (symbolTable == '/') { Serial.println(F("Normal")); } else { Serial.println(F("Alternate")); }
     Serial.print(F("Symbol:       ")); Serial.println(symbol);
     Serial.print(F("Power:        ")); if (power < 10) { Serial.println(power); } else { Serial.println(F("N/A")); }
     Serial.print(F("Height:       ")); if (height < 10) { Serial.println(height); } else { Serial.println(F("N/A")); }


### PR DESCRIPTION
I got a compile time warning
```/home/tim/arduino-1.6.12/libraries/LibAPRS/LibAPRS.cpp: In function 'void APRS_printSettings()':
/home/tim/arduino-1.6.12/libraries/LibAPRS/LibAPRS.cpp:187:61: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
     Serial.print(F("Symbol table: ")); if (symbolTable = '/') { Serial.println(F("Normal")); } else { Serial.println(F("Alternate")); }
                                                             ^
```
I believe you were looking for a comparison rather than an assignment so that you could indicate whether the normal or alternate symbol table was in use. Currently it would alway indicate the normal table is in use and displaying the current settings clobbers the symbolTable back to the normal every time.