### PR TITLE
Dynamic 300 baud

### DIFF
--- a/LibAPRS/AFSK.h
+++ b/LibAPRS/AFSK.h
@@ -29,8 +29,9 @@ inline static uint8_t sinSample(uint16_t i) {
     return (i >= (SIN_LEN/2)) ? (255 - sine) : sine;
 }
 
-
-#define SWITCH_TONE(inc)  (((inc) == MARK_INC) ? SPACE_INC : MARK_INC)
+#define DIV_ROUND(dividend, divisor)  (((dividend) + (divisor) / 2) / (divisor))
+#define SWITCH_TONE_300(inc)  (((inc) == MARK_INC_300) ? SPACE_INC_300 : MARK_INC_300)
+#define SWITCH_TONE_1200(inc)  (((inc) == MARK_INC_1200) ? SPACE_INC_1200 : MARK_INC_1200)
 #define BITS_DIFFER(bits1, bits2) (((bits1)^(bits2)) & 0x01)
 #define DUAL_XOR(bits1, bits2) ((((bits1)^(bits2)) & 0x03) == 0x03)
 #define SIGNAL_TRANSITIONED(bits) DUAL_XOR((bits), (bits) >> 2)
@@ -44,15 +45,23 @@ inline static uint8_t sinSample(uint16_t i) {
 #define CONFIG_AFSK_PREAMBLE_LEN 150UL
 #define CONFIG_AFSK_TRAILER_LEN 50UL
 #define SAMPLERATE 9600
-#define BITRATE    1200
-#define SAMPLESPERBIT (SAMPLERATE / BITRATE)
+#define SAMPLESPERBIT_1200 (SAMPLERATE / 1200)
+#define SAMPLESPERBIT_300 (SAMPLERATE / 300)
 #define BIT_STUFF_LEN 5
-#define MARK_FREQ  1200
-#define SPACE_FREQ 2200
+#define MARK_FREQ_300  1600
+#define SPACE_FREQ_300 1800
+#define MARK_FREQ_1200  1200
+#define SPACE_FREQ_1200 2200
 #define PHASE_BITS   8                              // How much to increment phase counter each sample
 #define PHASE_INC    1                              // Nudge by an eigth of a sample each adjustment
-#define PHASE_MAX    (SAMPLESPERBIT * PHASE_BITS)   // Resolution of our phase counter = 64
-#define PHASE_THRESHOLD  (PHASE_MAX / 2)            // Target transition point of our phase window
+#define PHASE_MAX_300 (SAMPLESPERBIT_300 * PHASE_BITS)   // Resolution of our phase counter = 64
+#define PHASE_MAX_1200 (SAMPLESPERBIT_1200 * PHASE_BITS)   // Resolution of our phase counter = 64
+#define PHASE_THRESHOLD_300  (PHASE_MAX_300 / 2)            // Target transition point of our phase window
+#define PHASE_THRESHOLD_1200  (PHASE_MAX_1200 / 2)            // Target transition point of our phase window
+#define MARK_INC_300   (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)MARK_FREQ_300, CONFIG_AFSK_DAC_SAMPLERATE))
+#define SPACE_INC_300  (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)SPACE_FREQ_300, CONFIG_AFSK_DAC_SAMPLERATE))
+#define MARK_INC_1200   (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)MARK_FREQ_1200, CONFIG_AFSK_DAC_SAMPLERATE))
+#define SPACE_INC_1200  (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)SPACE_FREQ_1200, CONFIG_AFSK_DAC_SAMPLERATE))
 
 
 typedef struct Hdlc
@@ -85,13 +94,13 @@ typedef struct Afsk
     uint16_t phaseInc;                      // Phase increment per sample
 
     FIFOBuffer txFifo;                      // FIFO for transmit data
-    uint8_t txBuf[CONFIG_AFSK_TX_BUFLEN];   // Actial data storage for said FIFO
+    uint8_t txBuf[CONFIG_AFSK_TX_BUFLEN];   // Actual data storage for said FIFO
 
     volatile bool sending;                  // Set when modem is sending
 
     // Demodulation values
     FIFOBuffer delayFifo;                   // Delayed FIFO for frequency discrimination
-    int8_t delayBuf[SAMPLESPERBIT / 2 + 1]; // Actual data storage for said FIFO
+    int8_t delayBuf[SAMPLESPERBIT_300 / 2 + 1]; // Actual data storage for said FIFO
 
     FIFOBuffer rxFifo;                      // FIFO for received data
     uint8_t rxBuf[CONFIG_AFSK_RX_BUFLEN];   // Actual data storage for said FIFO
@@ -100,16 +109,13 @@ typedef struct Afsk
     int16_t iirY[2];                        // IIR Filter Y cells
 
     uint8_t sampledBits;                    // Bits sampled by the demodulator (at ADC speed)
-    int8_t currentPhase;                    // Current phase of the demodulator
+    int16_t currentPhase;                   // Current phase of the demodulator
     uint8_t actualBits;                     // Actual found bits at correct bitrate
 
     volatile int status;                    // Status of the modem, 0 means OK
-
+    uint16_t dataRate;                      // Data rate for the modem
 } Afsk;
 
-#define DIV_ROUND(dividend, divisor)  (((dividend) + (divisor) / 2) / (divisor))
-#define MARK_INC   (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)MARK_FREQ, CONFIG_AFSK_DAC_SAMPLERATE))
-#define SPACE_INC  (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)SPACE_FREQ, CONFIG_AFSK_DAC_SAMPLERATE))
 
 #define AFSK_DAC_IRQ_START()   do { extern bool hw_afsk_dac_isr; hw_afsk_dac_isr = true; } while (0)
 #define AFSK_DAC_IRQ_STOP()    do { extern bool hw_afsk_dac_isr; hw_afsk_dac_isr = false; } while (0)
@@ -131,6 +137,7 @@ typedef struct Afsk
 void AFSK_init(Afsk *afsk);
 void AFSK_transmit(char *buffer, size_t size);
 void AFSK_poll(Afsk *afsk);
+void AFSK_setDataRate(Afsk *afsk, uint16_t rate);
 
 void afsk_putchar(char c);
 int afsk_getchar(void);

--- a/LibAPRS/AX25.cpp
+++ b/LibAPRS/AX25.cpp
@@ -16,6 +16,7 @@
 extern int LibAPRS_vref;
 extern bool LibAPRS_open_squelch;
 
+
 void ax25_init(AX25Ctx *ctx, ax25_callback_t hook) {
     memset(ctx, 0, sizeof(*ctx));
     ctx->hook = hook;

--- a/LibAPRS/LibAPRS.cpp
+++ b/LibAPRS/LibAPRS.cpp
@@ -68,7 +68,7 @@ void APRS_poll(void) {
     ax25_poll(&AX25);
 }
 
-void APRS_setCallsign(char *call, int8_t ssid) {
+void APRS_setCallsign(char *call, int ssid) {
     memset(CALL, 0, MAX_CALL_LENGTH);
     int i = 0;
     while (i < 6 && call[i] != 0) {
@@ -78,7 +78,7 @@ void APRS_setCallsign(char *call, int8_t ssid) {
     CALL_SSID = ssid;
 }
 
-void APRS_setDestination(char *call, int8_t ssid) {
+void APRS_setDestination(char *call, int ssid) {
     memset(DST, 0, MAX_CALL_LENGTH);
     int i = 0;
     while (i < 6 && call[i] != 0) {
@@ -88,7 +88,7 @@ void APRS_setDestination(char *call, int8_t ssid) {
     DST_SSID = ssid;
 }
 
-void APRS_setPath1(char *call, int8_t ssid) {
+void APRS_setPath1(char *call, int ssid) {
     memset(PATH1, 0, MAX_CALL_LENGTH);
     int i = 0;
     while (i < 6 && call[i] != 0) {
@@ -98,7 +98,7 @@ void APRS_setPath1(char *call, int8_t ssid) {
     PATH1_SSID = ssid;
 }
 
-void APRS_setPath2(char *call, int8_t ssid) {
+void APRS_setPath2(char *call, int ssid) {
     memset(PATH2, 0, MAX_CALL_LENGTH);
     int i = 0;
     while (i < 6 && call[i] != 0) {
@@ -108,7 +108,7 @@ void APRS_setPath2(char *call, int8_t ssid) {
     PATH2_SSID = ssid;
 }
 
-void APRS_setMessageDestination(char *call, int8_t ssid) {
+void APRS_setMessageDestination(char *call, int ssid) {
     memset(message_recip, 0, 6);
     int i = 0;
     while (i < 6 && call[i] != 0) {

--- a/LibAPRS/LibAPRS.cpp
+++ b/LibAPRS/LibAPRS.cpp
@@ -68,6 +68,14 @@ void APRS_poll(void) {
     ax25_poll(&AX25);
 }
 
+void APRS_setDataRate300() {
+    AFSK_setDataRate(&modem, 300);
+}
+
+void APRS_setDataRate1200() {
+    AFSK_setDataRate(&modem, 1200);
+}
+
 void APRS_setCallsign(char *call, int ssid) {
     memset(CALL, 0, MAX_CALL_LENGTH);
     int i = 0;
@@ -132,6 +140,10 @@ void APRS_useAlternateSymbolTable(bool use) {
     } else {
         symbolTable = '/';
     }
+}
+
+void APRS_setSymbolTable(char table) {
+    symbolTable = table;
 }
 
 void APRS_setSymbol(char sym) {
@@ -370,6 +382,11 @@ uint8_t APRS_sendLoc_mice(void *_buffer, size_t length) {
 
     memcpy(path2.call, PATH2, 6);
     path2.ssid = PATH2_SSID;
+
+    for (int i=0; i<6; i++) {
+        Serial.print((char)DST[i]);
+    }
+
 
     path[0] = dst;
     path[1] = src;

--- a/LibAPRS/LibAPRS.cpp
+++ b/LibAPRS/LibAPRS.cpp
@@ -20,13 +20,13 @@ AX25Call path2;
 
 #define MAX_CALL_LENGTH 7
 char CALL[MAX_CALL_LENGTH] = "NOCALL";
-int8_t CALL_SSID = 0;
+int CALL_SSID = 0;
 char DST[MAX_CALL_LENGTH] = "APZMDM";
-int8_t DST_SSID = 0;
+int DST_SSID = 0;
 char PATH1[MAX_CALL_LENGTH] = "WIDE1";
-int8_t PATH1_SSID = 1;
+int PATH1_SSID = 1;
 char PATH2[MAX_CALL_LENGTH] = "WIDE2";
-int8_t PATH2_SSID = 2;
+int PATH2_SSID = 2;
 uint8_t MICE_MSG;
 uint8_t MICE_SSID;
 
@@ -47,8 +47,8 @@ uint16_t course;
 /////////////////////////
 
 // Message packet assembly fields
-char message_recip[6];
-int8_t message_recip_ssid = -1;
+char message_recip[7];
+int message_recip_ssid = -1;
 
 int message_seq = 0;
 char lastMessage[67];

--- a/LibAPRS/LibAPRS.h
+++ b/LibAPRS/LibAPRS.h
@@ -11,11 +11,11 @@
 void APRS_init(int reference, bool open_squelch);
 void APRS_poll(void);
 
-void APRS_setCallsign(char *call, int8_t ssid);
-void APRS_setDestination(char *call, int8_t ssid);
-void APRS_setMessageDestination(char *call, int8_t ssid);
-void APRS_setPath1(char *call, int8_t ssid);
-void APRS_setPath2(char *call, int8_t ssid);
+void APRS_setCallsign(char *call, int ssid);
+void APRS_setDestination(char *call, int ssid);
+void APRS_setMessageDestination(char *call, int ssid);
+void APRS_setPath1(char *call, int ssid);
+void APRS_setPath2(char *call, int ssid);
 
 void APRS_setPreamble(unsigned long pre);
 void APRS_setTail(unsigned long tail);

--- a/LibAPRS/LibAPRS.h
+++ b/LibAPRS/LibAPRS.h
@@ -28,11 +28,17 @@ void APRS_setPower(int s);
 void APRS_setHeight(int s);
 void APRS_setGain(int s);
 void APRS_setDirectivity(int s);
+void APRS_setSpeed(int s);
+void APRS_setCourse(int c);
 
 void APRS_sendPkt(void *_buffer, size_t length);
 void APRS_sendLoc(void *_buffer, size_t length);
 void APRS_sendMsg(void *_buffer, size_t length);
 void APRS_msgRetry();
+uint8_t APRS_sendLoc_mice(void *_buffer, size_t length);
+void APRS_set_mice_ssid(uint8_t ssid);
+void APRS_set_mice_msg(uint8_t msg, bool custom);
+
 
 void APRS_printSettings();
 

--- a/LibAPRS/LibAPRS.h
+++ b/LibAPRS/LibAPRS.h
@@ -30,6 +30,7 @@ void APRS_setPreamble(unsigned long pre);
 void APRS_setTail(unsigned long tail);
 void APRS_useAlternateSymbolTable(bool use);
 void APRS_setSymbol(char sym);
+void APRS_setSymbolTable(char table);
 
 void APRS_setLat(char *lat);
 void APRS_setLon(char *lon);
@@ -39,6 +40,8 @@ void APRS_setGain(int s);
 void APRS_setDirectivity(int s);
 void APRS_setSpeed(int s);
 void APRS_setCourse(int c);
+void APRS_setDataRate300();
+void APRS_setDataRate1200();
 
 void APRS_sendPkt(void *_buffer, size_t length);
 void APRS_sendLoc(void *_buffer, size_t length);

--- a/LibAPRS/LibAPRS.h
+++ b/LibAPRS/LibAPRS.h
@@ -8,6 +8,15 @@
 #include "AFSK.h"
 #include "AX25.h"
 
+#define MICE_STD_MSG_OFF_DUTY 0x07
+#define MICE_STD_MSG_EN_ROUTE 0x06
+#define MICE_STD_MSG_IN_SERVICE 0x05
+#define MICE_STD_MSG_RETURNING 0x04
+#define MICE_STD_MSG_COMMITTED 0x03
+#define MICE_STD_MSG_SPECIAL 0x02
+#define MICE_STD_MSG_PRIORITY 0x01
+#define MICE_STD_MSG_EMERGENCY 0x00
+
 void APRS_init(int reference, bool open_squelch);
 void APRS_poll(void);
 

--- a/LibAPRS/LibAPRS.h
+++ b/LibAPRS/LibAPRS.h
@@ -11,11 +11,11 @@
 void APRS_init(int reference, bool open_squelch);
 void APRS_poll(void);
 
-void APRS_setCallsign(char *call, int ssid);
-void APRS_setDestination(char *call, int ssid);
-void APRS_setMessageDestination(char *call, int ssid);
-void APRS_setPath1(char *call, int ssid);
-void APRS_setPath2(char *call, int ssid);
+void APRS_setCallsign(char *call, int8_t ssid);
+void APRS_setDestination(char *call, int8_t ssid);
+void APRS_setMessageDestination(char *call, int8_t ssid);
+void APRS_setPath1(char *call, int8_t ssid);
+void APRS_setPath2(char *call, int8_t ssid);
 
 void APRS_setPreamble(unsigned long pre);
 void APRS_setTail(unsigned long tail);


### PR DESCRIPTION
This builds upon the previous pull request to add MIC-E support. 

This pull request adds dynamically selectable 1200 or 300 baud TX. The RX _should_ still work at 1200 but is untested.

This might seem a little crazy at first glance but here in Australia we run a national VHF APRS network on 145.175MHz at 1200 baud and a national HF network on 10.147MHz at 300 baud. The VHF coverage is mostly good for the populated areas but if you are travelling in the outback outside the VHF coverage HF is a must. 

Using a radio that works on both HF and VHF, a single modem can operate on both frequencies and baud rates. The radio can be controlled via another software serial port on the Arduino to send commands to put the radio on the correct band/frequency/mode before sending the position report.

It's probably a good idea to check the changes I've done to AFSK.* because I've mostly hacked it using educated guesses until I got something that worked.