### PR TITLE
Samplerate is to low for 4-bit DAC

### DIFF
--- a/src/AFSK.cpp
+++ b/src/AFSK.cpp
@@ -30,9 +30,9 @@ void AFSK_hw_init(void) {
 
     AFSK_hw_refDetect();
 
-    TCCR1A = 0;                                    
+    TCCR1A = 0;
     TCCR1B = _BV(CS10) | _BV(WGM13) | _BV(WGM12);
-    ICR1 = (((CPU_FREQ+FREQUENCY_CORRECTION)) / 9600) - 1;
+    ICR1 = (((CPU_FREQ+FREQUENCY_CORRECTION)) / SAMPLERATE) - 1;
 
     if (hw_5v_ref) {
         ADMUX = _BV(REFS0) | 0;
@@ -45,7 +45,7 @@ void AFSK_hw_init(void) {
     DIDR0 |= _BV(0);
     ADCSRB =    _BV(ADTS2) |
                 _BV(ADTS1) |
-                _BV(ADTS0);  
+                _BV(ADTS0);
     ADCSRA =    _BV(ADEN) |
                 _BV(ADSC) |
                 _BV(ADATE)|
@@ -184,7 +184,7 @@ static bool hdlcParse(Hdlc *hdlc, bool bit, FIFOBuffer *fifo) {
     // the left by one bit, to make room for the
     // next incoming bit
     hdlc->demodulatedBits <<= 1;
-    // And then put the newest bit from the 
+    // And then put the newest bit from the
     // demodulator into the byte.
     hdlc->demodulatedBits |= bit ? 1 : 0;
 
@@ -205,9 +205,9 @@ static bool hdlcParse(Hdlc *hdlc, bool bit, FIFOBuffer *fifo) {
             }
         } else {
             // If the buffer is full, we have a problem
-            // and abort by setting the return value to     
+            // and abort by setting the return value to
             // false and stopping the here.
-            
+
             ret = false;
             hdlc->receiving = false;
             LED_RX_OFF();
@@ -255,7 +255,7 @@ static bool hdlcParse(Hdlc *hdlc, bool bit, FIFOBuffer *fifo) {
     // a control character. Therefore, if we detect such a
     // "stuffed bit", we simply ignore it and wait for the
     // next bit to come in.
-    // 
+    //
     // We do the detection by applying an AND bit-mask to the
     // stream of demodulated bits. This mask is 00111111 (0x3f)
     // if the result of the operation is 00111110 (0x3e), we
@@ -333,7 +333,7 @@ void AFSK_adc_isr(Afsk *afsk, int8_t currentSample) {
     afsk->iirX[1] = ((int8_t)fifo_pop(&afsk->delayFifo) * currentSample) >> 2;
 
     afsk->iirY[0] = afsk->iirY[1];
-    
+
     afsk->iirY[1] = afsk->iirX[0] + afsk->iirX[1] + (afsk->iirY[0] >> 1); // Chebyshev filter
 
 
@@ -347,7 +347,7 @@ void AFSK_adc_isr(Afsk *afsk, int8_t currentSample) {
     fifo_push(&afsk->delayFifo, currentSample);
 
     // We need to check whether there is a signal transition.
-    // If there is, we can recalibrate the phase of our 
+    // If there is, we can recalibrate the phase of our
     // sampler to stay in sync with the transmitter. A bit of
     // explanation is required to understand how this works.
     // Since we have PHASE_MAX/PHASE_BITS = 8 samples per bit,
@@ -363,13 +363,13 @@ void AFSK_adc_isr(Afsk *afsk, int8_t currentSample) {
     //   Past                                      Future
     //       0000000011111111000000001111111100000000
     //                   |________|
-    //                       ||     
+    //                       ||
     //                     Window
     //
     // Every time we detect a signal transition, we adjust
     // where this window is positioned little. How much we
     // adjust it is defined by PHASE_INC. If our current phase
-    // phase counter value is less than half of PHASE_MAX (ie, 
+    // phase counter value is less than half of PHASE_MAX (ie,
     // the window size) when a signal transition is detected,
     // add PHASE_INC to our phase counter, effectively moving
     // the window a little bit backward (to the left in the
@@ -462,7 +462,7 @@ ISR(ADC_vect) {
     TIFR1 = _BV(ICF1);
     AFSK_adc_isr(AFSK_modem, ((int16_t)((ADC) >> 2) - 128));
     if (hw_afsk_dac_isr) {
-        DAC_PORT = (AFSK_dac_isr(AFSK_modem) & 0xF0) | _BV(3); 
+        DAC_PORT = (AFSK_dac_isr(AFSK_modem) & 0xF0) | _BV(3);
     } else {
         DAC_PORT = 128;
     }

--- a/src/AFSK.h
+++ b/src/AFSK.h
@@ -39,11 +39,11 @@ inline static uint8_t sinSample(uint16_t i) {
 #define CPU_FREQ F_CPU
 
 #define CONFIG_AFSK_RX_BUFLEN 64
-#define CONFIG_AFSK_TX_BUFLEN 64   
+#define CONFIG_AFSK_TX_BUFLEN 64
 #define CONFIG_AFSK_RXTIMEOUT 0
 #define CONFIG_AFSK_PREAMBLE_LEN 150UL
 #define CONFIG_AFSK_TRAILER_LEN 50UL
-#define SAMPLERATE 9600
+#define SAMPLERATE CONFIG_AFSK_DAC_SAMPLERATE
 #define BITRATE    1200
 #define SAMPLESPERBIT (SAMPLERATE / BITRATE)
 #define BIT_STUFF_LEN 5
@@ -74,7 +74,7 @@ typedef struct Afsk
     uint16_t tailLength;                    // Length of transmission tail
 
     // Modulation values
-    uint8_t sampleIndex;                    // Current sample index for outgoing bit 
+    uint8_t sampleIndex;                    // Current sample index for outgoing bit
     uint8_t currentOutputByte;              // Current byte to be modulated
     uint8_t txBit;                          // Mask of current modulated bit
     bool bitStuff;                          // Whether bitstuffing is allowed
@@ -108,8 +108,8 @@ typedef struct Afsk
 } Afsk;
 
 #define DIV_ROUND(dividend, divisor)  (((dividend) + (divisor) / 2) / (divisor))
-#define MARK_INC   (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)MARK_FREQ, CONFIG_AFSK_DAC_SAMPLERATE))
-#define SPACE_INC  (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)SPACE_FREQ, CONFIG_AFSK_DAC_SAMPLERATE))
+#define MARK_INC   (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)MARK_FREQ, SAMPLERATE))     //32
+#define SPACE_INC  (uint16_t)(DIV_ROUND(SIN_LEN * (uint32_t)SPACE_FREQ, SAMPLERATE))    //59
 
 #define AFSK_DAC_IRQ_START()   do { extern bool hw_afsk_dac_isr; hw_afsk_dac_isr = true; } while (0)
 #define AFSK_DAC_IRQ_STOP()    do { extern bool hw_afsk_dac_isr; hw_afsk_dac_isr = false; } while (0)

--- a/src/device.h
+++ b/src/device.h
@@ -17,7 +17,7 @@
 #endif
 
 // Sampling & timer setup
-#define CONFIG_AFSK_DAC_SAMPLERATE 9600
+#define CONFIG_AFSK_DAC_SAMPLERATE 28800
 
 // Port settings
 #if TARGET_CPU == m328p


### PR DESCRIPTION
Hi Mark,

I'm experimenting with the LibAPRS and measured the output signal from the DAC. While doing so, I noticed, that there aren't 16 voltage levels per sine wave as I would have expected from a 4-bit DAC. Instead I saw 8 voltage levels at 1200Hz and 4 voltage levels at 2200Hz with the original sample rate of 9.6kHz. To get the full performance out of the signal generation a sample rate of 35.2kHz would be necessary (2.2kHz*16=35.2kHz).
So I tried the maximum possible sample rate (in terms of execution time) and come to ~33kHz with the RX routine enable (but no RX signal) and 38kHz with the RX routine disabled. I did not tested the maximum possible sample rate with a RX signal, so that may vary. (All tests with 16MHz clock)
With that in mind, I decided to use a sample rate of 28.8kHz to use a round number and leave some headroom. With that I got 16 voltage levels at 1200Hz and 13 voltage levels at 2200Hz.
I also got a much better output signal in terms of harmonics (as far as I could measure it).

As far as I looked, this issue is shared between all implementations of your APRS code and probably also build into the purchasable trackers that use your library. This fork is the only sign I found, that someone had a play with the sample rate before (it also took my attention to take a look at the sample rate): https://github.com/zouppen/LibAPRS/commit/9e543533b4d908881a11c56ae10798e0d1dedd50

But maybe this shows also the advantages of your DAC implementation over a PWM, when it even works with a fewer number of voltage levels than expected from a 4-bit DAC.

For testing all of this a I added a test tone output as you can see here: 
https://github.com/jstjst/LibAPRS/tree/testtone
https://github.com/jstjst/APRS-Tracker/blob/master/APRS-Freq-Test/APRS-Freq-Test.ino

Thanks
Jonas